### PR TITLE
Windows Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx laiso/site2pdf <main_url> [url_pattern]
 ### Example
 
 ```bash
-npx laiso/site2pdf 'https://www.typescriptlang.org/docs/handbook/' 'https://www.typescriptlang.org/docs/handbook/2/'
+npx laiso/site2pdf "https://www.typescriptlang.org/docs/handbook/" "https://www.typescriptlang.org/docs/handbook/2/"
 ```
 
 ```bash
@@ -53,6 +53,16 @@ PDF saved to ./out/www-typescriptlang-org-docs-handbook.pdf
 ```
 
 This command will generate a PDF file named `www.typescriptlang.org-docs-handbook.pdf` containing all pages on the `https://www.typescriptlang.org/docs/handbook/` domain that match the pattern `https://www.typescriptlang.org/docs/handbook/2/`.
+
+## Troubleshooting for Windows
+
+When running Puppeteer on Windows, you may encounter permission issues related to generating PDFs. To resolve this, you need to grant appropriate permissions. Follow these steps:
+
+```powershell
+icacls %USERPROFILE%/.cache/puppeteer/chrome /grant *S-1-15-2-1:(OI)(CI)(RX)
+```
+
+[Troubleshooting - Chrome reports sandbox errors on Windows| Puppeteer](https://pptr.dev/troubleshooting#chrome-reports-sandbox-errors-on-windows)
 
 ## Implementation Details
 

--- a/bin/site2pdf.js
+++ b/bin/site2pdf.js
@@ -9,8 +9,12 @@ const args = process.argv.slice(2);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const result = spawnSync("npx", ["tsx", path.resolve(__dirname, '../index.ts'), ...args], {
-	stdio: "inherit",
-});
+const result = spawnSync(
+	"npx",
+	["tsx", path.resolve(__dirname, "../index.ts"), ...args],
+	{
+		stdio: "inherit",
+	},
+);
 
 process.exit(result.status);

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { cpus } from "node:os";
 
 import puppeteer, { type Browser } from "puppeteer";
@@ -94,6 +95,9 @@ async function main() {
 	const urlPattern = process.argv[3]
 		? new RegExp(process.argv[3])
 		: new RegExp(`^${mainURL}`);
+	console.log(
+		`Generating PDF for ${mainURL} and sub-links matching ${urlPattern}`,
+	);
 	const browser = await puppeteer.launch();
 	try {
 		const pdfBuffer = await generatePDF(browser, mainURL, urlPattern);
@@ -113,6 +117,6 @@ async function main() {
 	}
 }
 
-if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {
+if (fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
 	main();
 }


### PR DESCRIPTION
These changes add support for running the tool in a Windows environment.

## Updates in `index.ts`:
Replaced `import.meta.url` with `fileURLToPath(import.meta.url)` to ensure the main function is called when the module is executed directly. This improves Node.js ES module compatibility.

## Updates in `README.md`:
Added a troubleshooting section to address potential permission issues when running Puppeteer on Windows. Provided specific PowerShell commands and related links for resolving these issues. Also, changed the quotes in the example URLs from single to double quotes.

https://github.com/laiso/site2pdf/blob/b7ab0c9e21efa10b22db1b6957af25df89ec86a1/README.md?plain=1#L57-L65