### PR TITLE
Rename Package and Update CLI Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo apt-get install -y fonts-liberation libappindicator3-1 libatk-bridge2.0-0 l
 ## Usage
 
 ```bash
-npx laiso/site2pdf <main_url> [url_pattern]
+npx site2pdf-cli <main_url> [url_pattern]
 ```
 
 ### Arguments
@@ -43,7 +43,7 @@ npx laiso/site2pdf <main_url> [url_pattern]
 ### Example
 
 ```bash
-npx laiso/site2pdf "https://www.typescriptlang.org/docs/handbook/" "https://www.typescriptlang.org/docs/handbook/2/"
+npx site2pdf-cli "https://www.typescriptlang.org/docs/handbook/" "https://www.typescriptlang.org/docs/handbook/2/"
 ```
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "site2pdf",
-	"version": "1.0.0",
+	"name": "site2pdf-cli",
+	"version": "0.1.0",
 	"type": "module",
 	"description": "Generate comprehensive PDFs of entire websites, ideal for RAG. ",
 	"bin": {


### PR DESCRIPTION
- Changed the package name from site2pdf to site2pdf-cli.
- Updated the CLI command from npx laiso/site2pdf to npx site2pdf-cli.
- Made it possible to run the package without requiring git in the environment.

https://github.com/laiso/site2pdf/blob/61c961cc859c41c5c662e9f1bce62ebb707a7854/README.md?plain=1#L45-L47