### PR TITLE
without relying on tsx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm install
 The project uses TypeScript. To compile the TypeScript files, run:
 
 ```bash
-npx tsc
+npm run build
 ```
 
 ### Running the Project

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This tool generates a PDF file containing the main page and all sub-pages of a w
 **🖼️Visual Information Preservation:** By generating results in PDF format, visual information like images is preserved, ensuring better recognition by multimodal models.  
 
 ## Prerequisites
-
+****
 To run this software, you need to have Node.js installed on your machine. You can download and install the latest version of Node.js from [the official Node.js website](https://nodejs.org/).
 
 ### Dependencies(Linux)

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import { main } from '../dist/index.js';
+
+const [,, mainUrl, urlPattern] = process.argv;
+
+main(mainUrl, urlPattern);

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
 	},
 	"scripts": {
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-		"start": "tsx src/index.ts",
+		"start": "node dist/index.js",
 		"dev": "tsx watch src/index.ts",
+		"build": "tsc",
 		"publish": "npm publish",
 		"lint": "biome lint",
 		"format": "biome format"
@@ -30,7 +31,8 @@
 		"@types/jest": "^29.5.12",
 		"jest": "^29.7.0",
 		"ts-jest": "^29.2.2",
-		"tsx": "^4.7.2"
+		 "tsx": "^4.7.2",
+		"typescript": "^5.2.2"
 	},
 	"dependencies": {
 		"p-limit": "^6.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,14 +10,16 @@
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"isolatedModules": true,
-		"noEmit": true,
+		"noEmit": false,
 		"resolveJsonModule": true,
 		"incremental": true,
 		"baseUrl": ".",
 		"paths": {
 			"site2pdf/*": ["src/*"]
-		}
+		},
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
-	"include": ["**/*"],
-	"exclude": ["node_modules", "out"]
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
package.json updates:

Modified the start script to run the built JavaScript file.
Updated the dev script to use tsx in watch mode.
Added a build script to compile TypeScript files.
Added typescript as a dependency and organized dependencies for ts-node and tsx.
tsconfig.json updates:

Changed the module option to esnext to enable import.meta.
Set noEmit to false to output compiled files.
Configured outDir to dist to output compiled files to the dist directory.
src/index.ts updates:

Added logic to check if the script is run directly using import.meta.
These changes establish a workflow where TypeScript files are built and then executed, and during development, tsx can be used in watch mode.

To verify that this PR works correctly, run the following commands:

Additionally, during development, you can use the following command to run in watch mode: