### PR TITLE
v0.1.6: Improve PDF generation robustness and error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "site2pdf-cli",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"type": "module",
 	"description": "Generate comprehensive PDFs of entire websites, ideal for RAG. ",
 	"bin": {


### PR DESCRIPTION
## v0.1.6 Release Notes

**Improvements:**

-   Improved PDF generation robustness and error handling.
    -   Updated the `generatePDF` function to handle page generation errors.
    -   Changed the page load strategy to `domcontentloaded`.
    -   Added error logging and filtering for failed page PDF generations, including skipping timed-out pages.
    -   Made the `concurrentLimit` parameter optional, defaulting to the value from `cpus()`.
    -   Ensured proper page closure after PDF generation.

These changes make the PDF generation process more stable and improve handling when errors occur.

## Issue(#15)

```
❯ npx tsx ./src/index.ts  https://block.github.io/goose/docs/category/getting-started
Generating PDF for https://block.github.io/goose/docs/category/getting-started and sub-links matching /^https:\/\/block.github.io\/goose\/docs\/category\/getting-started/
loading https://block.github.io/goose/docs/category/getting-started
Warning: Error occurred while processing https://block.github.io/goose/docs/category/getting-started: TimeoutError: Timed out after waiting 30000ms
PDF saved to /Users/kstg/work/laiso/site2pdf/out/block-github-io-goose-docs-category-getting-started.pdf
```

### v0.1.6

```
❯ npx tsx ./src/index.ts   https://block.github.io/goose/docs/quickstart docs
Generating PDF for https://block.github.io/goose/docs/quickstart and sub-links matching /docs/
loading https://block.github.io/goose/docs/quickstart
loading https://block.github.io/goose/docs/category/getting-started
loading https://block.github.io/goose/docs/category/guides
loading https://block.github.io/goose/docs/category/tutorials
loading https://block.github.io/goose/docs/category/architecture-overview
loading https://block.github.io/goose/docs/troubleshooting
loading https://block.github.io/goose/docs/getting-started/providers
loading https://block.github.io/goose/docs/guides/handling-llm-rate-limits-with-goose
loading https://block.github.io/goose/docs/getting-started/using-extensions
loading https://block.github.io/goose/docs/guides/using-goosehints
Generated PDF for https://block.github.io/goose/docs/guides/using-goosehints
loading https://block.github.io/goose/docs/getting-started/installation
Generated PDF for https://block.github.io/goose/docs/guides/handling-llm-rate-limits-with-goose
Generated PDF for https://block.github.io/goose/docs/troubleshooting
Generated PDF for https://block.github.io/goose/docs/getting-started/using-extensions
Generated PDF for https://block.github.io/goose/docs/getting-started/providers
Generated PDF for https://block.github.io/goose/docs/getting-started/installation
Warning: Error occurred while processing https://block.github.io/goose/docs/quickstart: TimeoutError: Timed out after waiting 30000ms
Warning: Error occurred while processing https://block.github.io/goose/docs/category/guides: TimeoutError: Timed out after waiting 30000ms
Warning: Error occurred while processing https://block.github.io/goose/docs/category/getting-started: TimeoutError: Timed out after waiting 30000ms
Warning: Error occurred while processing https://block.github.io/goose/docs/category/tutorials: TimeoutError: Timed out after waiting 30000ms
Warning: Error occurred while processing https://block.github.io/goose/docs/category/architecture-overview: TimeoutError: Timed out after waiting 30000ms
PDF saved to /Users/kstg/work/laiso/site2pdf/out/block-github-io-goose-docs-quickstart.pdf
```

fix #15