### PR TITLE
docs: add global installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ npx site2pdf-cli https://example.com
 
 Output is saved to `./out/<domain>.pdf`.
 
-## Installation
+## Installation (from source)
 
-To install the tool globally on your machine, run:
+To install the tool globally on your machine from source, run:
 
 ```bash
+git clone https://github.com/laiso/site2pdf.git
+cd site2pdf
+npm install
 npm run build
 npm link
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ npx site2pdf-cli https://example.com
 
 Output is saved to `./out/<domain>.pdf`.
 
+## Installation
+
+To install the tool globally on your machine, run:
+
+```bash
+npm run build
+npm link
+```
+
+After installation, you can run the tool directly using the `site2pdf` command from anywhere:
+
+```bash
+site2pdf <main_url> [url_pattern]
+```
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) (v18 or later recommended)
@@ -112,7 +127,7 @@ npm install
 
 | Command | Description |
 |---------|-------------|
-| `npm run dev` | Run in development mode with watch |
+| `npm run dev -- <main_url> [url_pattern]` | Run in development mode with watch |
 | `npm run build` | Compile TypeScript |
 | `npm test` | Run tests |
 | `npx biome lint` | Check for lint issues |


### PR DESCRIPTION
## Summary
This PR adds instructions to the README on how to install the `site2pdf` tool globally using `npm link`, allowing it to be run directly as a command from anywhere on the system.